### PR TITLE
Minor tweaks: .gitignore and valid grid ID values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Vim swap files
+.*.sw*

--- a/bmi_tester/bmitester.py
+++ b/bmi_tester/bmitester.py
@@ -305,8 +305,6 @@ class BmiTester(Tester):
         """Test var grids."""
         grid = self.bmi.get_var_grid(name)
         assert_is_instance(grid, int)
-        assert_greater_equal(grid, 0)
-        assert_less_equal(grid, 2)
         return str(grid)
 
     def test_get_var_rank(self):


### PR DESCRIPTION
Edited .gitignore to ignore vim swapfiles;
  Vim uses swapfiles named:  .<file_being_edited>.swp
  if there is more than one swapfile for the file, the new swapfile is named: .<file_being_edited>.swo
  etc.

Edited bmitester.py to allow grid IDs to be any integer instead of just 0, 1, or 2
  removed two lines of code that checked this special case of the bmi-python example