### PR TITLE
Test grid type and shape for 'all input and output grids' 

### DIFF
--- a/bmi_tester/bmitester.py
+++ b/bmi_tester/bmitester.py
@@ -344,14 +344,17 @@ class BmiTester(Tester):
 
     def test_get_grid_type(self):
         """Test the grid type."""
-        grids = (0, 1, 2)
+        grids = []
+        for name in set(self.bmi.get_input_var_names()) | set(self.bmi.get_output_var_names()):
+            grids.append( self.bmi.get_var_grid(name) )
         self.foreach(grids, self._test_grid_type)
 
     def test_get_grid_shape(self):
         """Test the grid shape."""
-        grids = (0, 1, 2)
+        grids = []
+        for name in set(self.bmi.get_input_var_names()) | set(self.bmi.get_output_var_names()):
+            grids.append( self.bmi.get_var_grid(name) )
         self.foreach(grids, self._test_grid_shape)
-
 
 if __name__ == '__main__':
     tester = BmiTester(Component(), file=_INPUT_FILE)


### PR DESCRIPTION
The current version of bmi-tester tests the type and shape of grids 0, 1, and 2.

This update tests all the input and output grids instead.

Comment 1: I did this by appending to a list.  Perhaps there is a more pythonic way of creating that list?

Comment 2: The code passes the "shape" test even if the return value is "no shape."  Is that okay?