### PR TITLE
don't separately test initialize(); allow testing even if initial value of array is NaN

### DIFF
--- a/bmi_tester/bmitester.py
+++ b/bmi_tester/bmitester.py
@@ -11,6 +11,7 @@ from nose.tools import (assert_is_instance, assert_greater_equal,
                         assert_greater, assert_in)
 
 from .termcolors import red, green, yellow, blink
+import math
 
 # from components import InfilGreenAmpt as Component
 
@@ -383,9 +384,9 @@ class BmiTester(Tester):
         assert_in(units, ('s', 'seconds', 'd', 'days', 'y', 'years'))
         return units
 
-    #def test_get_value(self):
-    # get_value() is tested via test_get_input_values() and 
-    #   test_get_output_values()
+    # get_value() is tested via test_get_input_values() and
+    #    test_get_output_values() and is not tested separately
+    # def test_get_value(self):
 
     def test_get_input_values(self):
         """Input values are numpy arrays."""
@@ -515,9 +516,11 @@ class BmiTester(Tester):
         names = set(self.bmi.get_input_var_names()) | set(self.bmi.get_output_var_names())
         self.foreach(names, self._test_var_units)
 
-    def test_initialize(self):
-        """Test initialization from a file."""
-        self.bmi.initialize(self._file)
+    # initialize is called by __init__() and therefore
+    # does not need a separate test
+    # def test_initialize(self):
+    #     """Test initialization from a file."""
+    #      self.bmi.initialize(self._file)
 
     def test_get_value_and_set_value(self):
         """Test if we can get and set the value of (input) variables"""
@@ -569,7 +572,10 @@ class BmiTester(Tester):
                     val_first_value = val[0, 0, 0]
 
                 # Replace the first value of the array with a new value
-                val_test_value += val_first_value + 1
+                if math.isnan(val_first_value):
+                    val_test_value = 1
+                else:
+                    val_test_value += val_first_value + 1
                 if valrank == 1:
                     self.bmi.set_value_at_indices(name,
                                                   [0], val_test_value)


### PR DESCRIPTION
Three suggested changes:

1. Re-ordered text around the non-testing of test_get_value(self)  [Purely cosmetic]

2. Removed the test of initialize() because this is done in the setup before every test.  And it was failing when I wasn't passing a config file to the routine because I was testing a BMI routine that could use, but didn't need, a specified config file

3. In order to test get/set at indices, bmi-tester gets an array's values, increments the first value, and set's the first indices to that value.  But I had initialized the arrays to NaN -- actually np.nan -- so the increment operation was causing an error.  I import the math module to get access to math.isnan() so I can check for this condition and instead use the value "1" as the value that gets used in set_value_at_indices().