### PR TITLE
Add --stage argument to stage the tests with defaults.

### DIFF
--- a/bmi_tester/bmipytest.py
+++ b/bmi_tester/bmipytest.py
@@ -3,7 +3,11 @@ from __future__ import print_function
 
 import argparse
 import sys
+import tempfile
 import textwrap
+
+from model_metadata.api import query, stage
+from scripting import cd
 
 from .api import check_bmi
 
@@ -43,20 +47,35 @@ def configure_parser_test(sub_parsers=None):
     )
     p.add_argument("--bmi-version", default="1.1", help="BMI version to test against")
     p.add_argument("--help-pytest", action="store_true", help="Print help for pytest")
+    p.add_argument(
+        "--stage", action="store_true", help="Stage with defaults for testing"
+    )
     p.set_defaults(func=execute)
 
     return p
 
 
 def execute(args, extra):
-    return check_bmi(
-        args.cls,
-        input_file=args.infile,
-        manifest=args.manifest,
-        bmi_version=args.bmi_version,
-        extra_args=extra,
-        help_pytest=args.help_pytest,
-    )
+    if args.stage:
+        stage_dir = tempfile.mkdtemp()
+        model = args.cls.split(":")[-1]
+        input_file = query(model, "run.config_file.path")
+        manifest = stage(model, stage_dir)
+    else:
+        input_file = args.infile
+        manifest = args.manifest
+        stage_dir = "."
+
+    print("Running tests in {0}".format(stage_dir))
+    with cd(stage_dir):
+        return check_bmi(
+            args.cls,
+            input_file=input_file,
+            manifest=manifest,
+            bmi_version=args.bmi_version,
+            extra_args=extra,
+            help_pytest=args.help_pytest,
+        )
 
 
 def main():

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - scripting
     - cfunits
     - standard_names
+    - model_metadata
 
 build:
   number: 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ cfunits
 standard_names
 pytest
 scripting
+model_metadata


### PR DESCRIPTION
This pull request adds a `--stage` argument to the `bmi-test` command. If this options is given, `bmi-test` will stage the given component (using `model_metadata.api.stage`) with defaults in a temporary folder and then run tests on the component using those input files.

Example usage,
```
bmi-test pymt_child.bmi:Child --stage
```