### PR TITLE
Add test for get_grid_node_count

### DIFF
--- a/bmi_tester/bmi.py
+++ b/bmi_tester/bmi.py
@@ -79,6 +79,9 @@ class Bmi(object):
     def get_grid_size(self, id_):
         return 12
 
+    def get_grid_node_count(self, id_):
+        return 12
+
     def get_grid_type(self, id_):
         return "uniform_rectilinear"
 

--- a/bmi_tester/tests_pytest/test_grid.py
+++ b/bmi_tester/tests_pytest/test_grid.py
@@ -31,3 +31,10 @@ def test_get_grid_type(initialized_bmi, gid):
     assert gtype in VALID_GRID_TYPES
     if gtype == "scalar":
         assert initialized_bmi.get_grid_rank(gid) == 0
+
+
+def test_get_grid_node_count(initialized_bmi, gid):
+    "Test number of nodes in grid {gid}".format(gid=gid)
+    size = initialized_bmi.get_grid_node_count(gid)
+    assert isinstance(size, int)
+    assert size > 0


### PR DESCRIPTION
This pull request adds a test for the *get_grid_node_count* method. The deprecated *get_grid_size* was being tested but not its replacement.