### PR TITLE
Fix read-only error with get_value test

### DIFF
--- a/bmi_tester/api.py
+++ b/bmi_tester/api.py
@@ -4,6 +4,7 @@ import ctypes.util
 import os
 import sys
 
+import numpy as np
 import pkg_resources
 import pytest
 import six
@@ -59,6 +60,35 @@ def suppress_stdout(streams):
     # Close the null files
     for fd in null_fds + save_fds:
         os.close(fd)
+
+
+def empty_var_buffer(bmi, var_name):
+    """Create an empty value buffer for a BMI variable.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from bmi_tester.api import empty_var_buffer
+
+    >>> class Bmi:
+    ...     def get_var_nbytes(self, name):
+    ...         return 128
+    ...     def get_var_type(self, name):
+    ...         return "int"
+
+    >>> buffer = empty_var_buffer(Bmi(), "var-name")
+    >>> np.any(buffer != 0)
+    True
+    >>> buffer[:] = 0
+    >>> np.all(buffer == 0)
+    True
+    """
+    nbytes = bmi.get_var_nbytes(var_name)
+    dtype = np.dtype(bmi.get_var_type(var_name))
+
+    values = np.frombuffer(np.random.bytes(nbytes), dtype=dtype).copy()
+
+    return values
 
 
 def check_units(units):

--- a/bmi_tester/tests/stage_3/test_value.py
+++ b/bmi_tester/tests/stage_3/test_value.py
@@ -4,41 +4,13 @@ import numpy as np
 import pytest
 # from pytest_dependency import depends
 
+from bmi_tester.api import empty_var_buffer
+
 from ..conftest import BMI_VERSION_STRING, INPUT_FILE, Bmi
 
 BMI_VERSION = StrictVersion(BMI_VERSION_STRING)
 
 BAD_VALUE = {"f": np.nan, "i": -999, "u": 0}
-
-
-def empty_var_buffer(bmi, var_name):
-    # gid = bmi.get_var_grid(var_name)
-    # if BMI_VERSION > "1.0":
-    #     loc = bmi.get_var_location(var_name)
-    # else:
-    #     warnings.warn(
-    #         "get_var_location not implemented (assuming nodes)", FutureWarning
-    #     )
-    #     loc = "node"
-
-    # if loc == "node":
-    #     size = bmi.get_grid_node_count(gid)
-    # elif loc == "edge":
-    #     size = bmi.get_grid_edge_count(gid)
-    # elif loc == "face":
-    #     size = bmi.get_grid_face_count(gid)
-    # else:
-    #     size = 0
-
-    # itemsize = bmi.get_var_itemsize(var_name)
-    # nbytes = itemsize * size
-    nbytes = bmi.get_var_nbytes(var_name)
-    dtype = np.dtype(bmi.get_var_type(var_name))
-
-    values = np.frombuffer(np.random.bytes(nbytes), dtype=dtype)
-    # values = np.empty(size, dtype=dtype)
-
-    return values
 
 
 # @pytest.mark.dependency()


### PR DESCRIPTION
This pull request fixes an error when testing the BMI *get_value* method where the *bmi-tester* creates a buffer to place data into but that buffer is read-only.