### PR TITLE
Allow dimensionless time units

### DIFF
--- a/bmi_tester/tests/stage_1/test_time.py
+++ b/bmi_tester/tests/stage_1/test_time.py
@@ -39,9 +39,7 @@ def test_time_units_is_valid(initialized_bmi):
     units = initialized_bmi.get_time_units()
     unit_system = Units()
     assert unit_system.is_valid(units)
-    assert unit_system.is_time(units)
-    # units = cfunits.Units(units)
-    # assert units.istime
+    assert unit_system.is_time(units) or unit_system.is_dimensionless(units)
 
 
 @pytest.mark.dependency(depends=["test_get_start_time", "test_get_end_time"])

--- a/bmi_tester/units.pyx
+++ b/bmi_tester/units.pyx
@@ -37,6 +37,7 @@ cdef extern from "udunits2.h":
     ut_unit* ut_parse(const ut_system* system, const char* string, int encoding)
     int ut_are_convertible(const ut_unit* unit1, const ut_unit* unit2)
     int ut_format(const ut_unit* unit, char* buf, size_t size, unsigned opts)
+    int ut_is_dimensionless(const ut_unit* unit)
 
 
 cdef class Units:
@@ -72,6 +73,10 @@ cdef class Units:
         src_unit = ut_parse(self._c_system, units.encode("utf-8"), 0)
         dst_unit = ut_parse(self._c_system, "s".encode("utf-8"), 0)
         return bool(ut_are_convertible(src_unit, dst_unit))
+
+    def is_dimensionless(self, units):
+        unit = ut_parse(self._c_system, units.encode("utf-8"), 0)
+        return ut_is_dimensionless(unit) != 0
 
     def __dealloc__(self):
         ut_free_system(self._c_system)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -19,3 +19,11 @@ def test_check_invalid_units():
     assert not unit_system.is_valid("foo")
     assert not unit_system.is_valid("m ** 2")
     assert not unit_system.is_valid("-")
+
+
+def test_dimensionless_units():
+    unit_system = Units()
+    assert unit_system.is_dimensionless("")
+    assert unit_system.is_dimensionless("1")
+    assert not unit_system.is_dimensionless("m")
+    assert not unit_system.is_dimensionless("-")


### PR DESCRIPTION
This pull request allows dimensionless units (i.e. *""*, *"1"*, but not *"-"*) to be used as time units for a BMI as returned by *get_time_units*.