### PR TITLE
Fix bmi version strings

### DIFF
--- a/bmi_tester/api.py
+++ b/bmi_tester/api.py
@@ -15,7 +15,7 @@ def check_bmi(
     tests_dir=None,
     input_file=None,
     manifest=None,
-    bmi_version="1.1",
+    bmi_version="2.0",
     extra_args=None,
     help_pytest=False,
 ):

--- a/bmi_tester/bmipytest.py
+++ b/bmi_tester/bmipytest.py
@@ -115,7 +115,7 @@ def _tree(files):
     ),
     help="Path to manifest file of staged model input files.",
 )
-@click.option("--bmi-version", default="1.1", help="BMI version to test against")
+@click.option("--bmi-version", default="2.0", help="BMI version to test against")
 @click.argument("entry_point", callback=validate_entry_point)
 @click.argument("pytest_args", nargs=-1, type=click.UNPROCESSED)
 def main(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[zest.releaser]
+tag-format = v{version}
+
 [flake8]
 exclude = docs
 ignore =


### PR DESCRIPTION
Although the *bmi-tester* was testing BMI *v2*, there were several places where *"1.x"* string was used. This pull request changes those strings to *"2.0"*.