### PR TITLE
Fix bug in unstructured grid tests

### DIFF
--- a/bmi_tester/tests/stage_3/test_grid.py
+++ b/bmi_tester/tests/stage_3/test_grid.py
@@ -78,7 +78,7 @@ def test_get_grid_face_count(initialized_bmi, gid):
 
 
 # @pytest.mark.dependency(depends=["test_get_grid_node_count", "test_get_grid_edge_count"])
-def test_get_grid_edges_nodes(initialized_bmi, gid):
+def test_get_grid_edge_nodes(initialized_bmi, gid):
     "Test nodes at edges for grid {gid}".format(gid=gid)
     skip_if_grid_type_is_not(initialized_bmi, gid, "unstructured")
 
@@ -90,7 +90,7 @@ def test_get_grid_edges_nodes(initialized_bmi, gid):
 
     edge_nodes = np.full((n_edges, 2), -1, dtype=int).reshape(-1)
 
-    rtn = initialized_bmi.get_grid_edges_node(gid, edge_nodes)
+    rtn = initialized_bmi.get_grid_edge_nodes(gid, edge_nodes)
     assert rtn is edge_nodes
     assert np.all(edge_nodes >= 0)
     assert np.all(edge_nodes < n_nodes)

--- a/bmi_tester/tests/stage_3/test_grid_unstructured.py
+++ b/bmi_tester/tests/stage_3/test_grid_unstructured.py
@@ -14,7 +14,7 @@ def test_grid_x(initialized_bmi, gid):
         pytest.skip(f"grid is rank {ndim}")
 
     if gtype == "unstructured":
-        size = initialized_bmi.get_grid_number_of_nodes(gid)
+        size = initialized_bmi.get_grid_node_count(gid)
     elif gtype == "rectilinear":
         shape = np.empty(ndim, dtype=np.int32)
         initialized_bmi.get_grid_shape(gid, shape)
@@ -35,7 +35,7 @@ def test_grid_y(initialized_bmi, gid):
         pytest.skip(f"grid is rank {ndim}")
 
     if gtype == "unstructured":
-        size = initialized_bmi.get_grid_number_of_nodes(gid)
+        size = initialized_bmi.get_grid_node_count(gid)
     elif gtype == "rectilinear":
         shape = np.empty(ndim, dtype=np.int32)
         initialized_bmi.get_grid_shape(gid, shape)
@@ -56,7 +56,7 @@ def test_grid_z(initialized_bmi, gid):
         pytest.skip(f"grid is rank {ndim}")
 
     if gtype == "unstructured":
-        size = initialized_bmi.get_grid_number_of_nodes(gid)
+        size = initialized_bmi.get_grid_node_count(gid)
     elif gtype == "rectilinear":
         shape = np.empty(ndim, dtype=np.int32)
         initialized_bmi.get_grid_shape(gid, shape)


### PR DESCRIPTION
This pull request fixes a couple errors in the testing of unstructured grids: a typo in the test of *get_grid_edge_nodes*, and the use of *get_grid_number_of_nodes* instead of *get_grid_node_count*.