### PR TITLE
Skip set value test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog for bmi-tester
 0.5.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Removed the test for set_value as it's just too dangerous (#26)
 
 
 0.5.3 (2020-10-19)

--- a/bmi_tester/tests/stage_3/test_value.py
+++ b/bmi_tester/tests/stage_3/test_value.py
@@ -38,6 +38,7 @@ def test_get_var_location(initialized_bmi, var_name):
     assert loc in ("node", "edge", "face", "none")
 
 
+@pytest.mark.skip("too dangerous")
 # @pytest.mark.dependency(depends=["initialize_works", "test_get_var_grid", "get_var_nbytes"], scope="session")
 def test_set_input_values(staged_tmpdir, in_var_name):
     """Input values are numpy arrays."""


### PR DESCRIPTION
This pull request removes (actually the test is still there, it's just skipped) the test for the BMI *set_value* method. Since it's difficult to know what valid values are for every variable of a model, this test can be dangerous since bad values can cause things like, for example, segmentation faults.