### PR TITLE
Use get_grid_node_count on unstructured grids

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_install:
     source $HOME/.bashrc
   fi
 - micromamba activate
-- micromamba install python=$PYTHON pip mamba --yes -c conda-forge
+- micromamba install python=$PYTHON -p $MAMBA_ROOT_PREFIX pip mamba --yes -c conda-forge
 install:
 - mamba install udunits2 --yes -c conda-forge
 - pip install .

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Changelog for bmi-tester
 - Removed the test for set_value as it's just too dangerous (#26)
 
 - Fixed tests that use get_grid_node_count on grids that
-  are not unstructured
+  are not unstructured (#27)
 
 
 0.5.3 (2020-10-19)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog for bmi-tester
 
 - Removed the test for set_value as it's just too dangerous (#26)
 
+- Fixed tests that use get_grid_node_count on grids that
+  are not unstructured
+
 
 0.5.3 (2020-10-19)
 ------------------

--- a/bmi_tester/tests/stage_2/test_var.py
+++ b/bmi_tester/tests/stage_2/test_var.py
@@ -48,12 +48,13 @@ def test_var_on_grid(initialized_bmi, var_name):
         pytest.skip(f"var, {var_name}, is not located on a grid")
 
     gid = initialized_bmi.get_var_grid(var_name)
-    if loc == "node":
-        assert initialized_bmi.get_grid_node_count(gid) > 0
-    elif loc == "edge":
-        assert initialized_bmi.get_grid_edge_count(gid) > 0
-    elif loc == "face":
-        assert initialized_bmi.get_grid_face_count(gid) > 0
+    if initialized_bmi.get_grid_type(gid) == "unstructured":
+        if loc == "node":
+            assert initialized_bmi.get_grid_node_count(gid) > 0
+        elif loc == "edge":
+            assert initialized_bmi.get_grid_edge_count(gid) > 0
+        elif loc == "face":
+            assert initialized_bmi.get_grid_face_count(gid) > 0
 
 
 def test_get_var_type(initialized_bmi, var_name):

--- a/bmi_tester/tests/stage_3/test_grid.py
+++ b/bmi_tester/tests/stage_3/test_grid.py
@@ -48,7 +48,7 @@ def test_get_grid_type(initialized_bmi, gid):
 # @pytest.mark.dependency()
 def test_get_grid_node_count(initialized_bmi, gid):
     "Test number of nodes in grid {gid}".format(gid=gid)
-    skip_if_grid_type_is(initialized_bmi, gid, "none")
+    skip_if_grid_type_is_not(initialized_bmi, gid, "unstructured")
 
     n_nodes = initialized_bmi.get_grid_node_count(gid)
     assert isinstance(n_nodes, int)

--- a/bmi_tester/tests/stage_3/test_grid.py
+++ b/bmi_tester/tests/stage_3/test_grid.py
@@ -3,7 +3,7 @@ from distutils.version import StrictVersion
 import numpy as np
 import pytest
 
-from ..conftest import skip_if_grid_type_is, skip_if_grid_type_is_not, BMI_VERSION
+from ..conftest import skip_if_grid_type_is_not, BMI_VERSION
 
 
 VALID_GRID_TYPES = (


### PR DESCRIPTION
This pull request fixes tests that use the `get_grid_node_count` method on grids that are not unstructured. The `get_grid_node_count` method should not be implemented for, say, uniform rectilinear grids (for uniform rectilinear grids, one can get the number of nodes through `get_grid_shape`).