### PR TITLE
Fix documentation builds on readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+version: 2
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: false
+
+formats:
+  - htmlzip
+
+conda:
+  environment: environment.yml
+
+python:
+  version: 3.8
+  install:
+    - method: pip
+      path: .
+  system_packages: false
+
+build:
+  image: latest

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: bmi-tester
+channels:
+  - conda-forge
+dependencies:
+- gimli.units
+- pip
+- pip:
+  - -r file:requirements.txt
+  - -r file:requirements-docs.txt


### PR DESCRIPTION
This pull request is to fix building the *bmi-tester* documentation on *readthedocs.io*. I've added two new files: *.readthedocs.yaml* and *environment.yml*.