### PR TITLE
Fix docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,3 +12,8 @@ sphinx:
   builder: html
   configuration: docs/conf.py
   fail_on_warning: false
+
+python:
+  install:
+    - method: pip
+      path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,15 +3,12 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "mambaforge-22.9"
+
+conda:
+  environment: environment.yml
 
 sphinx:
   builder: html
   configuration: docs/conf.py
   fail_on_warning: false
-
-python:
-  install:
-    - requirements: requirements-docs.txt
-    - method: pip
-      path: .

--- a/environment.yml
+++ b/environment.yml
@@ -2,10 +2,10 @@ name: bmi-tester
 channels:
   - conda-forge
 dependencies:
-- python >=3.9
-- pip
-- udunits2
-- pip:
-  - -r requirements.txt
-  - -r requirements-docs.txt
-  - -r requirements-testing.txt
+  - python >=3.9
+  - pip
+  - udunits2
+  - pip:
+    - -r requirements.txt
+    - -r requirements-docs.txt
+    - -r requirements-testing.txt

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: bmi-tester
 channels:
   - conda-forge
 dependencies:
+- python >=3.9
 - pip
 - udunits2
 - pip:


### PR DESCRIPTION
This PR fixes the failing docs build on rtfd.io. I had been trying to install dependencies through *pip*. However, *udunits2* has to be installed through *conda*. I switched up the rtfd configuration to use mambeforge and the `environment.yml` file included in the project. 