### PR TITLE
Allow non-zero start

### DIFF
--- a/src/bmi_tester/_tests/stage_1/time_test.py
+++ b/src/bmi_tester/_tests/stage_1/time_test.py
@@ -58,7 +58,7 @@ def test_get_current_time(initialized_bmi):
 @pytest.mark.skip()
 @pytest.mark.dependency(depends=["test_get_start_time"])
 def test_get_end_time(initialized_bmi):
-    """Test that there is a stop time."""
+    """Test that there is a stop time (and that it's after the start)."""
     start = initialized_bmi.get_start_time()
     stop = initialized_bmi.get_end_time()
 

--- a/src/bmi_tester/_tests/stage_1/time_test.py
+++ b/src/bmi_tester/_tests/stage_1/time_test.py
@@ -18,7 +18,6 @@ def test_get_start_time(initialized_bmi):
     start = initialized_bmi.get_start_time()
 
     assert isinstance(start, float)
-    assert start == approx(0.0)
 
 
 @pytest.mark.dependency()


### PR DESCRIPTION
Following the discussion with @mcflugen and others here: https://github.com/orgs/csdms/discussions/26 this PR does the very small and simple thing of dropping the requirement that the start time is 0.0. I also made a tiny tweak to the description of a later test.

(I would be interested in discussing whether negative time steps and having an end before the start is of interest- otherwise it might be good to require the time step to be positive! That's a separate discussion though!). 