### PR TITLE
Extending testing of set_value and get_value

### DIFF
--- a/src/bmi_tester/_tests/stage_2/var_test.py
+++ b/src/bmi_tester/_tests/stage_2/var_test.py
@@ -60,7 +60,7 @@ def test_get_var_units(initialized_bmi, var_name):
     assert isinstance(units, str)
     assert check_unit_is_valid(units)
 
-def test_put_get(initialized_bmi):
+def test_set_get_interaction(initialized_bmi):
     """Test fundmanetal state behaviour of every output variable which is also an input variable:"""
 
     # Take the intersection of output and input vars

--- a/src/bmi_tester/_tests/stage_2/var_test.py
+++ b/src/bmi_tester/_tests/stage_2/var_test.py
@@ -69,7 +69,7 @@ def test_put_get(initialized_bmi):
 
         # Get the variables type
         ty = np.dtype(initialized_bmi.get_var_type(var_name))
-        # Generate some systematic base cases for this type
+        # Generate some systematic test cases for this variable's type
         zero = np.zeros(1, dtype=ty)
         one  = np.ones(1, dtype=ty)
         for val in [zero, one, one + one]:

--- a/src/bmi_tester/_tests/stage_2/var_test.py
+++ b/src/bmi_tester/_tests/stage_2/var_test.py
@@ -76,9 +76,11 @@ def test_put_get(initialized_bmi):
           # Test set-get behaviour
           # (i.e., setting a value then getting it produces the same result)
           initialized_bmi.set_value(var_name, val)
-          assert initialized_bmi.get_value(var_name) == val
+          val_out = initialized_bmi.get_value(var_name)
+          assert val_out == val
 
           # Test set-set-get behaviour
           # (i.e., setting is idempotent; setting twice has no visible effect)
           initialized_bmi.set_value(var_name, val)
-          assert initialized_bmi.get_value(var_name) == val
+          val_out_again = initialized_bmi.get_value(var_name)
+          assert val_out_again == val_out

--- a/src/bmi_tester/_tests/stage_2/var_test.py
+++ b/src/bmi_tester/_tests/stage_2/var_test.py
@@ -59,3 +59,26 @@ def test_get_var_units(initialized_bmi, var_name):
     units = initialized_bmi.get_var_units(var_name)
     assert isinstance(units, str)
     assert check_unit_is_valid(units)
+
+def test_put_get(initialized_bmi):
+    """Test fundmanetal state behaviour of every output variable which is also an input variable:"""
+
+    # Take the intersection of output and input vars
+    for var_name in initialized_bmi.get_output_var_names():
+      if var_name in initialized_bmi.get_input_var_names():
+
+        # Get the variables type
+        ty = np.dtype(initialized_bmi.get_var_type(var_name))
+        # Generate some systematic base cases for this type
+        zero = np.zeros(1, dtype=ty)
+        one  = np.ones(1, dtype=ty)
+        for val in [zero, one, one + one]:
+          # Test set-get behaviour
+          # (i.e., setting a value then getting it produces the same result)
+          initialized_bmi.set_value(var_name, val)
+          assert initialized_bmi.get_value(var_name) == val
+
+          # Test set-set-get behaviour
+          # (i.e., setting is idempotent; setting twice has no visible effect)
+          initialized_bmi.set_value(var_name, val)
+          assert initialized_bmi.get_value(var_name) == val


### PR DESCRIPTION
There is this an idea in computer science about fundamental laws for implementations of 'state' which include things like putting a value into a store and then retrieving it yields the same result, or that putting the same value twice has the same effect as just doing it once.

I think that this could be checked for the intersection of input and output variables in a BMI to ensure that nothing untoward is happening underneath with `set_value` and `get_value`. There doesn't seem anything like this in the current `bmi-tester`. I have had a first pass at it here which seems to compile (but I need to try it on more things first), but would appreciate some discussion (and I don't mind if this gets closed without merge). Does this makes sense? Is it useful? 