### PR TITLE
Remove return statement from test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python-version }}
-          miniforge-variant: Mambaforge
           miniforge-version: latest
 
       - name: Test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,9 +57,8 @@ repos:
         )
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.8.0
+  rev: v1.16.0
   hooks:
   - id: mypy
     language_version: python3.12
-    additional_dependencies: [types-all]
     files: bmi_tester/.*\.py$

--- a/src/bmi_tester/_tests/stage_1/info_test.py
+++ b/src/bmi_tester/_tests/stage_1/info_test.py
@@ -10,8 +10,6 @@ def test_get_component_name(initialized_bmi):
     name = initialized_bmi.get_component_name()
     assert isinstance(name, str)
 
-    return name
-
 
 def test_var_names(var_name):
     """Test var names are valid."""


### PR DESCRIPTION
The latest version of *pytest* throws an error if a test returns anything other than `None`. I've removed a `return` statement from one test in *bmi-tester*.

This fixes #50.